### PR TITLE
Versions formatting ux

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -10,3 +10,4 @@
 @import "sort_button";
 @import "tabs";
 @import "service_title";
+@import "versions";

--- a/app/assets/stylesheets/components/_versions.scss
+++ b/app/assets/stylesheets/components/_versions.scss
@@ -1,0 +1,7 @@
+#panel-style {
+  background: white;
+
+  &:hover {
+    transform: translateY(-5px);
+  }
+}

--- a/app/assets/stylesheets/pages/_point.scss
+++ b/app/assets/stylesheets/pages/_point.scss
@@ -38,6 +38,10 @@
   padding: 15px;
 }
 
+.p30 {
+  padding: 30px;
+}
+
 .pl15 {
   padding-left: 15px;
 }

--- a/app/assets/stylesheets/pages/_point.scss
+++ b/app/assets/stylesheets/pages/_point.scss
@@ -88,4 +88,12 @@
   padding: 15px;
 }
 
+.fl {
+  float: left;
+}
+
+.fr {
+  float: right;
+}
+
 

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -42,6 +42,8 @@ class PointsController < ApplicationController
     @point
     puts @point.id
     @comments = Comment.where(point_id: @point.id)
+    @versions = @point.versions
+    @reaons = @point.reasons
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,14 @@
 module ApplicationHelper
+
+  def format_time(time)
+    time.strftime("%d/%m/%y - %H:%M")
+  end
+
+  def format_figures(figure, first = true)
+    if first
+      figure.nil? ? "No changes recorded" : figure.first
+    else
+      figure.nil? ? "No changes recorded" : figure.second
+    end
+  end
 end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -13,13 +13,14 @@ class Point < ApplicationRecord
  validates :rating, presence: true
  validates :rating, numericality: true
 
- def self.search_points_by_multiple(query)
+def self.search_points_by_multiple(query)
   Point.joins(:service).where("services.name ILIKE ? or points.status ILIKE ?", "%#{query}%", "%#{query}%")
 end
 
 def self.search_points_by_topic(query)
   Point.joins(:topic).where("topics.title ILIKE ?", "%#{query}%")
 end
+
 # VOTE CONTROLLER ! TODO
   # def has_voted(point)
   #   Vote.where(point_id: point.id, user_id: current_user.id)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,5 +37,8 @@
   </div>
   <%= render "shared/footer" %>
   <%= javascript_include_tag 'application' %>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/app/views/points/_table_reasons.html.erb
+++ b/app/views/points/_table_reasons.html.erb
@@ -7,11 +7,11 @@
   <% version.changeset['reason'].nil? ? reason = "No reason provided for previous changes" : reason = version.changeset["reason"].second %>
   <% counter += 1 %>
   <div class="panel panel-default" id="panel<%=counter%>">
-    <div class="panel-heading">
+    <div class="panel-heading" id="panel-style">
       <div class="row">
         <div class="col-sm-4">
           <h5>
-              Version <%= counter - 1 %>: <%= format_time(version.changeset["updated_at"].second.time) %>
+              <b>Version <%= counter - 1 %>:</b> <%= format_time(version.changeset["updated_at"].second.time) %>
           </h5>
         </div>
         <div class="col-sm-4">
@@ -34,11 +34,17 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-12 mb15">
-            <p>Reason for changes: <%= reason %></p>
-            <p>Previous Analysis: <%= format_figures(analysis) %></p>
-            <p>Updated Analysis: <%= format_figures(analysis, first = false) %></p>
-            <p>Previous Status: <%= format_figures(status) %></p>
-            <p>Updated Status: <%= format_figures(status, first = false) %></p>
+            <p><b>Reason for changes:</b> <%= reason %></p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-6">
+            <p><b>Previous Analysis:</b> <%= format_figures(analysis) %></p>
+            <p><b>Updated Analysis:</b> <%= format_figures(analysis, first = false) %></p>
+          </div>
+          <div class="col-sm-6">
+            <p><b>Previous Status:</b> <%= format_figures(status) %></p>
+            <p><b>Updated Status:</b> <%= format_figures(status, first = false) %></p>
           </div>
         </div>
       </div>

--- a/app/views/points/_table_reasons.html.erb
+++ b/app/views/points/_table_reasons.html.erb
@@ -1,46 +1,50 @@
-<div class="article-holder status-changes">
-
-  <!-- <table class="table">
-    <thead class="thead thead-dark">
-      <th scope="col">STATUS UPDATES</th>
-      <th scope="col">REASON</th>
-      <th scope="col">WHEN</th>
-    </thead>
-    <tbody>
-    <% @point.reasons.each do |reason| %>
-      <tr>
-        <th scope="row"><%= reason.status %></th>
-        <td><%= reason.content %></td>
-        <td><%= time_ago_in_words reason.created_at %> ago</td>
-      </tr>
-    </tbody>
-    <% end %>
-  </table> -->
-
-  <table class="table">
-    <thead class="thead thead-dark">
-      <th scope="col">ANALYSIS UPDATES</th>
-      <th scope="col">TEXT CHANGES</th>
-      <th scope="col">WHEN</th>
-      <!-- <th scope="col">WHO</th> -->
-    </thead>
-    <tbody>
-      <% @point.versions.each do |v| %>
-      <tr>
-        <th scope="row"><%= v.event %></th>
-        <td>
-          <% if v.changeset["analysis"] %>
-          Analysis change: <%= v.changeset["analysis"] %>
-          <% elsif v.changeset["status"] %>
-          Status change: <%= v.changeset["status"] %>
-          <% else %>
-          No changes recorded
-          <% end %>
-        </td>
-        <td><%= v.changeset["updated_at"] %></td>
-        <!-- make a better view for username <td><%= v.whodunnit %></td> -->
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+<div class="panel-group" id="accordion">
+  <% counter = 1 %>
+  <% @versions.each do |version| %>
+  <% event = version.event == "create" ? "Analysis created" : "Analysis updated" %>
+  <% analysis = version.changeset["analysis"] %>
+  <% status = version.changeset["status"] %>
+  <% version.changeset['reason'].nil? ? reason = "No reason provided for previous changes" : reason = version.changeset["reason"].second %>
+  <% counter += 1 %>
+  <div class="panel panel-default" id="panel<%=counter%>">
+    <div class="panel-heading">
+      <div class="row">
+        <div class="col-sm-4">
+          <h5>
+              Version <%= counter - 1 %>: <%= format_time(version.changeset["updated_at"].second.time) %>
+          </h5>
+        </div>
+        <div class="col-sm-4">
+          <h5>
+            <a data-toggle="collapse" data-target="#collapse<%=counter%>"
+              href="#collapse<%=counter%>" class="collapsed">
+              <%= event %>
+            </a>
+          </h5>
+        </div>
+        <div class="col-sm-4 text-right">
+          <a data-toggle="collapse" data-target="#collapse<%=counter%>"
+              href="#collapse<%=counter%>" class="collapsed">
+              <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
+          </a>
+        </div>
+    </div>
+  </div>
+    <div id="collapse<%=counter%>" class="panel-collapse collapse">
+      <div class="panel-body">
+        <div class="row">
+          <div class="col-sm-12 mb15">
+            <p>Reason for changes: <%= reason %></p>
+            <p>Previous Analysis: <%= format_figures(analysis) %></p>
+            <p>Updated Analysis: <%= format_figures(analysis, first = false) %></p>
+            <p>Previous Status: <%= format_figures(status) %></p>
+            <p>Updated Status: <%= format_figures(status, first = false) %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% end %>
 </div>
+</div>
+

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -1,81 +1,71 @@
-<div class="point-holder">
-
-  <div class="article-holder">
-    <div class="article-point-header">
-      <ul class="point-info">
-        <li class="point-items">
-          <div class="pl50">
-            <span class="bolder">Service:</span> <%= @point.service.name %>
-          </div>
-          <div class="pl50">
-            <span class="bolder">Status:</span> <%= @point.status %>
-          </div>
-          <div class="pl50">
-            <span class="bolder">Rating:</span> <%= @point.rating %>
-          </div>
-          <div class="pl50">
-            <span class="bolder">Changes:</span> <%= @point.versions.size %>
-          </div>
-        </li>
-      </ul>
-    </div>
+<div class="row">
+  <div class="col-sm-6">
+    <h4 class="lighter fl"><%= @point.title %></h4>
   </div>
-
-  <div class="article-holder">
-
-    <div class="article-point-header">
-      <h3 class="lighter"><%= @point.title %></h3>
+  <div class="col-sm-6">
+    <% if current_user %>
+    <div class="dropdown btn-group fr">
+        <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+            Update Point
+            <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+            <li><%= link_to 'Edit Content', edit_point_path(@point) %></li>
+            <li><%= link_to 'Update Status', new_point_reason_path(@point) %></li>
+            <li>
+              <% if @point.status == "approved" %>
+              <% if !@point.is_featured? %>
+              <%= link_to 'Feature', featured_point_path(@point), method: :put%>
+              <% else %>
+              <%= link_to 'Un-Feature', featured_point_path(@point), method: :put %>
+              <% end %>
+              <% end %>
+            </li>
+            <li>
+              <%= link_to 'Delete Point', @point, method: :delete %>
+            </li>
+        </ul>
     </div>
-
-    <div class="article-point-text-holder p15">
-      <div class="article-point-text pad-left pad-right">
-        <span class="bolder">Analysis:</span> <%= @point.analysis %>
-      </div>
-    </div>
-
+    <% end %>
   </div>
-
-  <div class="m15 mw6">
-    <ul class="point-info">
-      <li class="point-items">
-        <% unless current_user.nil? %>
-          <% if current_user.id == @point.user_id %>
-          <div>
-            <%= link_to 'Edit', edit_point_path(@point), class: 'btn btn-primary' %>
-          </div>
-          <% end %>
-        <% end %>
-        <div class="pl15">
-          <%= link_to 'All', points_path, class: 'btn btn-primary' %>
-        </div>
-
-        <% unless current_user.nil? %>
-        <% if current_user.curator? %>
-        <div class="pl15">
-          <%= link_to 'Update Status', new_point_reason_path(@point), class: 'btn btn-primary' %>
-        </div>
-        <div class="pl15">
-          <%= link_to 'Edit Point', edit_point_path(@point), class: 'btn btn-primary' %>
-        </div>
-        <div class="pl15">
-          <% if @point.status == "approved" %>
-          <% if !@point.is_featured? %>
-          <%= link_to 'Feature', featured_point_path(@point), method: :put, class: 'btn btn-primary' %>
-          <% else %>
-          <%= link_to 'Un-Feature', featured_point_path(@point), method: :put, class: 'btn btn-warning' %>
-          <% end %>
-          <% end %>
-        </div>
-        <div class="pl15">
-          <%= link_to 'Delete', @point, method: :delete, class: 'btn btn-danger' %>
-        </div>
-        <% end %>
-        <% end %>
-      </li>
-    </ul>
-  </div>
-
 </div>
+
+<br>
+
+<div class="row">
+  <div class="col-sm-3">
+    <span class="bolder">Service:</span> <%= @point.service.name %>
+  </div>
+  <div class="col-sm-3">
+    <span class="bolder">Status:</span> <%= @point.status %>
+  </div>
+  <div class="col-sm-3">
+    <span class="bolder">Rating:</span> <%= @point.rating %>
+  </div>
+  <div col-sm-3>
+    <span class="bolder">Changes:</span> <%= @point.versions.size %>
+  </div>
+</div>
+
+<br>
+<br>
+
+<div class="row">
+  <div class="col-sm-12">
+    <%= @point.analysis %>
+  </div>
+</div>
+
+<br>
+<br>
+
+<div class="row">
+  <div class="col-sm-12">
+    <span class="bolder">We track editorial changes to analyses and updates to a point's status and display the previous versions here as part of an effort to promote transparency regarding our curation process.</span>
+  </div>
+</div>
+
+<br>
 
 <% if @point.versions.any? %>
   <%= render 'table_reasons' %>

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="col-sm-6">
     <% if current_user %>
+    <% if current_user.curator %>
     <div class="dropdown btn-group fr">
         <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
             Update Point
@@ -26,6 +27,7 @@
             </li>
         </ul>
     </div>
+    <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -35,10 +35,6 @@
 
   </div>
 
-  <% if @point.reasons.any? || @point.versions.any? %>
-  <%= render 'table_reasons' %>
-  <% end %>
-
   <div class="m15 mw6">
     <ul class="point-info">
       <li class="point-items">
@@ -80,4 +76,8 @@
   </div>
 
 </div>
+
+<% if @point.versions.any? %>
+  <%= render 'table_reasons' %>
+<% end %>
 

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -51,7 +51,7 @@
 <br>
 
 <div class="row">
-  <div class="col-sm-12">
+  <div class="col-sm-10 col-sm-offset-1 p30 bgw">
     <%= @point.analysis %>
   </div>
 </div>

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -42,7 +42,7 @@
   <div class="col-sm-3">
     <span class="bolder">Rating:</span> <%= @point.rating %>
   </div>
-  <div col-sm-3>
+  <div class="col-sm-3">
     <span class="bolder">Changes:</span> <%= @point.versions.size %>
   </div>
 </div>

--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -59,6 +59,8 @@
 <br>
 <br>
 
+<% if @point.versions.any? %>
+
 <div class="row">
   <div class="col-sm-12">
     <span class="bolder">We track editorial changes to analyses and updates to a point's status and display the previous versions here as part of an effort to promote transparency regarding our curation process.</span>
@@ -67,7 +69,7 @@
 
 <br>
 
-<% if @point.versions.any? %>
-  <%= render 'table_reasons' %>
+<%= render 'table_reasons' %>
+
 <% end %>
 

--- a/db/migrate/20180414123052_add_change_reason_to_points.rb
+++ b/db/migrate/20180414123052_add_change_reason_to_points.rb
@@ -1,0 +1,5 @@
+class AddChangeReasonToPoints < ActiveRecord::Migration[5.1]
+  def change
+    add_column :points, :change_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116111454) do
+ActiveRecord::Schema.define(version: 20180414123052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,8 @@ ActiveRecord::Schema.define(version: 20180116111454) do
     t.string "quote"
     t.bigint "case_id"
     t.string "oldId"
+    t.text "reason"
+    t.text "change_reason"
     t.index ["case_id"], name: "index_points_on_case_id"
     t.index ["service_id"], name: "index_points_on_service_id"
     t.index ["topic_id"], name: "index_points_on_topic_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,13 +89,10 @@ ActiveRecord::Schema.define(version: 20180414123052) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "grade"
-    t.bigint "user_id"
-    t.string "status"
     t.string "wikipedia"
     t.string "keywords"
     t.string "related"
     t.string "slug"
-    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
   create_table "topics", force: :cascade do |t|
@@ -148,5 +145,4 @@ ActiveRecord::Schema.define(version: 20180414123052) do
   add_foreign_key "points", "users"
   add_foreign_key "reasons", "points"
   add_foreign_key "reasons", "users"
-  add_foreign_key "services", "users"
 end


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [enh] Please mention if it is a fix, enhancement or feature
* [->] Please explain your change

Re-did the versions table on points to improve and add coherence. The versions are displayed now using bootstrap's collapsing panel functionality, which I find to be more user-friendly than the table that was there before. The panels rely on a newer version of bootstrap, which in turn has some jquery dependencies. I added those to the application.html.erb file. I created two helper methods: one to format the changeset datetimes, and another to handle empty changesets for the fields that we track, which currently includes "reason," "status," and "analysis," though more can be added and adapted. I also made some minor cosmetic changes to the point show page, basically just getting rid of those random divs and using bootstraps rows and columns to make things cleaner. Kind of looks all over the place on the current live site.

Thanks !
