### PR TITLE
added 'reason' form input to point edit page

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -91,7 +91,7 @@ class PointsController < ApplicationController
   end
 
   def point_params
-    params.require(:point).permit(:title, :source, :status, :rating, :analysis, :topic_id, :service_id, :is_featured, :query)
+    params.require(:point).permit(:title, :source, :status, :rating, :analysis, :topic_id, :service_id, :is_featured, :query, :reason)
   end
 
   def points_get

--- a/app/views/points/_form.html.erb
+++ b/app/views/points/_form.html.erb
@@ -32,12 +32,21 @@
       <%= f.input :status, collection: ["pending", "draft"], hint: "Choose pending for the curators to review your point" %>
       <% end %>
     </div>
+    <% if params[:action] == "edit" %>
+    <div class="col-xs-12">
+      <%= f.input :reason, as: :text , input_html: { rows: 4, class: "text-area" }, hint: "Provide a reason for your changes to this analysis point." %>
+    </div>
+    <% end %>
     <div class="form-actions col-xs-4 col-sm-2 col-md-2">
       <%= link_to "Back", :back, class: "btn btn-default" %>
     </div>
     <div class="form-actions col-xs-8 col-sm-4 col-sm-offset-6 col-md-3 col-md-offset-7">
-      <%= f.submit "Submit Point", name: "only_create", class: 'btn btn-primary' %>
-      <%= f.submit "Submit Point + Add Another", name: "create_add_another", class: 'btn btn-primary' %>
+      <% if params[:action] == "new" %>
+        <%= f.submit "Submit", name: "only_create", class: 'btn btn-primary' %>
+        <%= f.submit "Submit + Add Another", name: "create_add_another", class: 'btn btn-primary' %>
+      <% else %>
+        <%= f.submit "Update", class: 'btn btn-primary' %>
+      <% end %>
     </div>
   </div>
   <% end %>

--- a/db/migrate/20180424095751_remove_change_reason_from_points.rb
+++ b/db/migrate/20180424095751_remove_change_reason_from_points.rb
@@ -1,0 +1,5 @@
+class RemoveChangeReasonFromPoints < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :points, :change_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180414123052) do
+ActiveRecord::Schema.define(version: 20180424095751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,9 +34,9 @@ ActiveRecord::Schema.define(version: 20180414123052) do
     t.integer "score"
     t.string "title"
     t.text "description"
-    t.bigint "topic_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "topic_id"
     t.index ["topic_id"], name: "index_cases_on_topic_id"
   end
 
@@ -65,7 +65,6 @@ ActiveRecord::Schema.define(version: 20180414123052) do
     t.bigint "case_id"
     t.string "oldId"
     t.text "reason"
-    t.text "change_reason"
     t.index ["case_id"], name: "index_points_on_case_id"
     t.index ["service_id"], name: "index_points_on_service_id"
     t.index ["topic_id"], name: "index_points_on_topic_id"
@@ -89,10 +88,13 @@ ActiveRecord::Schema.define(version: 20180414123052) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "grade"
+    t.bigint "user_id"
+    t.string "status"
     t.string "wikipedia"
     t.string "keywords"
     t.string "related"
     t.string "slug"
+    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
   create_table "topics", force: :cascade do |t|
@@ -137,7 +139,6 @@ ActiveRecord::Schema.define(version: 20180414123052) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  add_foreign_key "cases", "topics"
   add_foreign_key "comments", "points"
   add_foreign_key "points", "cases"
   add_foreign_key "points", "services"
@@ -145,4 +146,5 @@ ActiveRecord::Schema.define(version: 20180414123052) do
   add_foreign_key "points", "users"
   add_foreign_key "reasons", "points"
   add_foreign_key "reasons", "users"
+  add_foreign_key "services", "users"
 end


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [fix/enh] Please mention if it is a fix, enhancement or feature
* [->] Please explain your change

We're tracking the 'reason' column on points in the changesets but didn't have a form input for it on the point update page. Added the form input. Also, there was another column on point called "change_reason" that wasn't being used that I removed via a migration.

Thanks !
