### PR TITLE
Fixing errors on show point page in production

### DIFF
--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -11,6 +11,7 @@
             <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
+          <!-- Error is here I think -->
             <li><%= link_to 'Edit Content', edit_point_path(@point) %></li>
             <li><%= link_to 'Update Status', new_point_reason_path(@point) %></li>
             <li>


### PR DESCRIPTION
# Problems

* EDIT: Reason model works in production, I can create a Reason through the console in production. Routes seem fine and :reason is permitted in the parameters in the PointsController. So my guess is that the error is in the Show.html.erb page. Somehow on edit content, :reason is not set and this could be why the app crashed. As in the form called in the edit method, there is reason

* DELETE: While we are at it, the delete button fails as well as it requests comments. One part of this PR drop the table comments all together (#YOLO).

Note: I created a "Test service" as a dummy to test into production, please use this one.