### PR TITLE
Fix show point in production

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -37,6 +37,7 @@ class PointsController < ApplicationController
   end
 
   def edit
+    @point.reason = Reason.new
   end
 
   def show

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -37,7 +37,6 @@ class PointsController < ApplicationController
   end
 
   def edit
-    @point.reason = Reason.new
   end
 
   def show
@@ -49,6 +48,7 @@ class PointsController < ApplicationController
   end
 
   def update
+    # Maybe something is wrong here ? In local updates are not saved
     @point.update(point_params)
     flash[:notice] = "Point successfully updated!"
     redirect_to point_path(@point)

--- a/app/controllers/reasons_controller.rb
+++ b/app/controllers/reasons_controller.rb
@@ -2,7 +2,6 @@ class ReasonsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_curator, except: [:index, :show]
   before_action :set_point, only: [:new, :create]
-  before_action :set_admin
   def new
     @reason = Reason.new
   end
@@ -24,13 +23,6 @@ class ReasonsController < ApplicationController
   end
 
   private
-
-  def set_admin
-    unless current_user.curator?
-      redirect_to root_path
-      flash[:alert] = "You must be a curator"
-    end
-  end
 
   def set_point
     @point = Point.find(params[:point_id])

--- a/app/views/points/_form.html.erb
+++ b/app/views/points/_form.html.erb
@@ -34,7 +34,7 @@
     </div>
     <% if params[:action] == "edit" %>
     <div class="col-xs-12">
-      <%= f.input :reason, as: :text , input_html: { rows: 4, class: "text-area" }, hint: "Provide a reason for your changes to this analysis point." %>
+      <%= f.input :change_reason, as: :text, input_html: { rows: 4, class: "text-area" }, hint: "Provide a reason for your changes to this analysis point." %>
     </div>
     <% end %>
     <div class="form-actions col-xs-4 col-sm-2 col-md-2">

--- a/db/migrate/20180424095751_remove_reason_from_points.rb
+++ b/db/migrate/20180424095751_remove_reason_from_points.rb
@@ -1,0 +1,5 @@
+class RemoveReasonFromPoints < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :points, :reason, :text
+  end
+end


### PR DESCRIPTION
# Problems

* EDIT: Reason model works in production, I can create a Reason through the console in production. Routes seem fine and :reason is permitted in the parameters in the PointsController. So my guess is that the error is in the Show.html.erb page. Somehow on edit content, :reason is not set and this could be why the app crashed. As in the form called in the edit method, there is reason

* DELETE: While we are at it, the delete button fails as well as it requests comments. One part of this PR drop the table comments all together (#YOLO).

Note: I created a "Test service" as a dummy to test into production, please use this one.