### PR TITLE
quickfix for points that have nil versions

### DIFF
--- a/app/views/points/_table_reasons.html.erb
+++ b/app/views/points/_table_reasons.html.erb
@@ -8,6 +8,7 @@
   <% version.changeset['change_reason'].nil? ? reason = "No reason provided for previous changes" : reason = version.changeset["change_reason"].second %>
   <% else %>
   <% reason = "Cannot display the older versions" %>
+  <% end %>
   <% counter += 1 %>
   <div class="panel panel-default" id="panel<%=counter%>">
     <div class="panel-heading" id="panel-style">

--- a/app/views/points/_table_reasons.html.erb
+++ b/app/views/points/_table_reasons.html.erb
@@ -4,7 +4,10 @@
   <% event = version.event == "create" ? "Analysis created" : "Analysis updated" %>
   <% analysis = version.changeset["analysis"] %>
   <% status = version.changeset["status"] %>
+  <% unless version.nil? %>
   <% version.changeset['change_reason'].nil? ? reason = "No reason provided for previous changes" : reason = version.changeset["change_reason"].second %>
+  <% else %>
+  <% reason = "Cannot display the older versions" %>
   <% counter += 1 %>
   <div class="panel panel-default" id="panel<%=counter%>">
     <div class="panel-heading" id="panel-style">


### PR DESCRIPTION
* [X] Are you working on the latest release?
* [X] Have you tested it locally?
* [fix] Please mention if it is a fix, enhancement or feature
* [X] Please explain your change

The points imported seem not to have a paper_trail version resulting in a unknown method. Only happening in production, let's see if this fixes it. 

Thanks !
