### PR TITLE
Force auth for some indexes

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -1,5 +1,5 @@
 class PointsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:show]
   before_action :set_curator, only: [:edit, :featured, :destroy]
   before_action :set_point, only: [:show, :edit, :featured, :update, :destroy]
   before_action :points_get, only: [:index]

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,5 +1,5 @@
 class ServicesController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:show]
   before_action :set_curator, except: [:index, :show]
   before_action :set_service, only: [:show, :edit, :update, :destroy]
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,5 +1,5 @@
 class TopicsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:show]
   before_action :set_curator, except: [:index, :show]
   before_action :set_topic, only: [:show, :edit, :update, :destroy]
 


### PR DESCRIPTION
* [X] Are you working on the latest release?
* [X] Have you tested it locally?
* [X] Please mention if it is a fix, enhancement or feature
* [X] Please explain your change

Ok, this one might be a bit controversial as it won't allow not-logged users to see indexes of Topics, Points and Services. So just logged users can see them. I think that in the long term it could be cool to open that to not logged users but as Phoenix is a tool for work, this is why I made this choices because it could lead to errors through trying to access `/services`, `topics` or `points` through the url. 

I'm open for discussion for the next versions of the beta. 
