### PR TITLE
Bring back comments on points

### DIFF
--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -64,6 +64,15 @@
 <br>
 <br>
 
+<div class="row">
+  <div class="container card-container">
+    <%= render 'comments', comments: @comments %>
+  </div>
+</div>
+
+<br>
+<br>
+
 <% if !@point.versions.nil? %>
 
 <div class="row">


### PR DESCRIPTION
I started working on this in December; the comments of a point are meant to be like [Wikipedia Talk pages](https://en.wikipedia.org/wiki/Talk:TL;DR), and I'm using it for importing the mailing list discussion thread import.

Continuing that now.