### PR TITLE
[Enh] Remove text-shadows from cards

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -23,7 +23,6 @@
     text-overflow: ellipsis;
     overflow: auto;
     border-radius: 4px 4px 0px 0px;
-    text-shadow: 0px 1px 2px #01BAEF;
   }
   & .card-block {
     display: flex;
@@ -102,7 +101,6 @@ $pointPaddingLeft : 35px;
   width: 70px;
   border-radius: 50%;
   color: white;
-  text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.5);
   text-align: center;
   font-size: 48px;
   font-weight: bold;


### PR DESCRIPTION
This is just a small change and I'm not sure to what extent we're catering to them and how attached we are to the shadows, but visually impaired users can have a hard time with the text-shadows that are currently in the application. Thus, I'd suggest removing them.

I've added @madoleary as a reviewer as she originally added them :)