### PR TITLE
[fix] Performance of the homepage

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -38,26 +38,19 @@ class Service < ApplicationRecord
     unless avg.nan?
       case avg.round
       when 9..10
-        self.update_attributes(grade:"A")
         "A"
       when 7..8
-        self.update_attributes(grade:"B")
         "B"
       when 5..6
-        self.update_attributes(grade:"C")
         "C"
       when 3..4
-        self.update_attributes(grade:"D")
         "D"
       when 0..2
-        self.update_attributes(grade:"F")
         "F"
       else
-        self.update_attributes(grade:"N/A")
         "N/A"
       end
     else
-      self.update_attributes(grade:"N/A")
       "N/A"
     end
   end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -67,21 +67,7 @@
 <!-- Services -->
   <div class="row row-form" id="service-container">
       <% @services.each do |s| %>
-        <div class="col-xs-12 col-sm-6 col-lg-4 serviceDiv" data-rating="<%= s.service_ratings %>" >
-
-          <% if s.service_ratings == "A" %>
-            <% grade = "rating-a" %>
-          <% elsif s.service_ratings == "B" %>
-            <% grade = "rating-b" %>
-          <% elsif s.service_ratings == "C" %>
-            <% grade = "rating-c" %>
-          <% elsif s.service_ratings == "D" %>
-            <% grade = "rating-d" %>
-          <% elsif s.service_ratings == "F" %>
-            <% grade = "rating-f" %>
-          <% else %>
-            <% grade = "rating-na" %>
-          <% end %>
+        <div class="col-xs-12 col-sm-6 col-lg-4 serviceDiv">
 
           <!-- CARD -->
           <div class="card">
@@ -90,7 +76,7 @@
             </div>
             <div class="card-block">
               <div class="card-left">
-                <div class="card-left-item card-badge <%= grade %>">
+                <div class="card-left-item card-badge <%= s.rating_for_view %>">
                   <%= s.service_ratings %>
                 </div>
                 <%= link_to "More", service_path(s.id), class: "btn btn-primary box-shadow-for-button" %>

--- a/db/migrate/20180523100609_remove_grade_from_services.rb
+++ b/db/migrate/20180523100609_remove_grade_from_services.rb
@@ -1,0 +1,5 @@
+class RemoveGradeFromServices < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :services, :grade, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180502090354) do
+ActiveRecord::Schema.define(version: 20180523100609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,7 +87,6 @@ ActiveRecord::Schema.define(version: 20180502090354) do
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "grade"
     t.string "wikipedia"
     t.string "keywords"
     t.string "related"


### PR DESCRIPTION
More details about the exact changes can be found on the commit: f6d729102194e65aef47992332188c0b6cc43e20

Basically, what I've done is remove the storage of a service's grade in the database. When you accessed a service's grade through `Service.service_ratings`, not only was that grade recalculated, but the result was also (possible redundantly) inserted into the database. Thus, I've changed it to no longer store it in the database, under the assumption that code already never accessed `Service.grade` directly (since you could not be sure that it was up-to-date) - please do confirm if that assumption is true.

I also updated the view to use `Service.rating_for_view`, which appeared to have been written for that purpose - although I guess that logic should really belong in the view after all?

Note that this also adds a new migration, which could be relevant when deploying?

Fixes #258.