### PR TITLE
[enh] Some UX tweaks for the homepage

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,19 +1,12 @@
 .card {
   margin: 10px -5px;
-  height: 300px;
-  min-width: 300px;
   background-color: white;
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.3);
   border-radius: 4px;
   transition: 200ms !important;
 
-  &:hover {
-    box-shadow: 1px 5px 5px rgba(0, 0, 0, 0.1);
-    transform: translateY(-5px);
-  }
-
   & .card-service {
-    height: 51.25px;
+    padding: $padding-base-vertical $padding-base-horizontal;
     font-size: 36px;
     font-weight: 500;
     letter-spacing: 1.75px;
@@ -21,7 +14,7 @@
     background-color: rgba(0, 0, 0, 0.05);
     border-bottom: 0.25px solid rgba(0, 0, 0, 0.3) ;
     text-overflow: ellipsis;
-    overflow: auto;
+    overflow: hidden;
     border-radius: 4px 4px 0px 0px;
   }
   & .card-block {

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,62 +1,42 @@
+$badge-radius: 35px;
+
 .card {
-  margin: 10px -5px;
+  display: flex;
+  flex-direction: column;
   background-color: white;
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
-  transition: 200ms !important;
+  border-radius: $border-radius-base;
+  height: 300px;
 
   & .card-service {
+    margin: 0;
     padding: $padding-base-vertical $padding-base-horizontal;
-    font-size: 36px;
-    font-weight: 500;
+    font-size: $font-size-h2;
+    font-weight: $headings-font-weight;
     letter-spacing: 1.75px;
     text-align: center;
-    background-color: rgba(0, 0, 0, 0.05);
-    border-bottom: 0.25px solid rgba(0, 0, 0, 0.3) ;
+    background-color: $gray-lighter;
     text-overflow: ellipsis;
     overflow: hidden;
-    border-radius: 4px 4px 0px 0px;
+    border-radius: $border-radius-base $border-radius-base 0 0;
   }
   & .card-block {
-    display: flex;
-    padding: 10px 10px;
+    flex-grow: 1;
+    padding: $padding-large-vertical $padding-large-horizontal;
 
-    & .card-left {
+    .card-text {
       display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      flex: 0 0 70px;
-      padding: 20px 10px;
-      & .rating-na {
-        font-size: 1em;
-        padding-top: 24px;
+      flex-direction: row;
+      justify-content: space-between;
+
+      ul {
+        max-height: 150px;
+        overflow: hidden;
       }
     }
-    & .card-left-item {
-      margin: 50px 0;
-    }
-    & .card-text {
-      flex: 0 1 auto;
-      font-size: 0.9em;
-      line-height: 1.07em;
-      padding: 5px;
-      height: 228px;
-      text-overflow: ellipsis;
-      overflow: auto;
-    }
-    & .card-text p {
-      margin: 0.5em;
-      text-align: justify;
-      max-height: 100px;
-    }
-    & .card-text ul {
-      list-style-type: none;
-      padding: 0;
-      margin: 0 0 0 5px;
-      & li {
-        margin-bottom: 5px;
-      }
-    }
+  }
+  .card-footer {
+    padding: $padding-large-vertical;
   }
 }
 
@@ -90,8 +70,8 @@ $pointPaddingLeft : 35px;
 
 
 .card-badge {
-  height: 70px;
-  width: 70px;
+  height: $badge-radius * 2;
+  min-width: $badge-radius * 2;
   border-radius: 50%;
   color: white;
   text-align: center;

--- a/app/assets/stylesheets/components/_sort_button.scss
+++ b/app/assets/stylesheets/components/_sort_button.scss
@@ -1,3 +1,7 @@
+.sorting-buttons {
+  padding-bottom: $padding-large-vertical;
+}
+
 #orderByRating {
   border-radius: 4px;
  padding-left: 12px;

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -73,7 +73,7 @@
 
           <!-- CARD -->
           <div class="card">
-            <div class="card-service">
+            <div class="card-service" title="<%= s.name %>">
               <%= s.name %>
             </div>
             <div class="card-block">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -67,22 +67,16 @@
       <% end %>
 
 <!-- Services -->
-  <div class="row row-form" id="service-container">
+  <div class="row" id="service-container">
       <% @services.each do |s| %>
         <div class="col-xs-12 col-sm-6 col-lg-4 serviceDiv" data-rating="<%= s.service_ratings %>">
 
           <!-- CARD -->
           <div class="card">
-            <div class="card-service" title="<%= s.name %>">
+            <h2 class="card-header card-service" title="<%= s.name %>">
               <%= s.name %>
-            </div>
-            <div class="card-block">
-              <div class="card-left">
-                <div class="card-left-item card-badge <%= s.rating_for_view %>">
-                  <%= s.service_ratings %>
-                </div>
-                <%= link_to "More", service_path(s.id), class: "btn btn-primary box-shadow-for-button" %>
-              </div>
+            </h2>
+            <div class="card-body card-block">
               <div class="card-text">
                 <ul>
                   <% s.points.each do |p| %>
@@ -102,8 +96,14 @@
                     <% end %>
                   <% end %>
                 </ul>
+                <div class="card-badge <%= s.rating_for_view %>">
+                  <%= s.service_ratings %>
+                </div>
               </div>
             </div>
+            <footer class="card-footer">
+              <%= link_to "More", service_path(s.id), class: "btn btn-primary box-shadow-for-button" %>
+            </footer>
           </div>
           <!-- CARD-END -->
         </div>


### PR DESCRIPTION
I've cleaned up the CSS a bit (using predefined variables instead of [magic numbers](https://css-tricks.com/magic-numbers-in-css/)).

Furthermore, I've moved the ratings to the right, so that the points are all equally aligned from the left-hand side, making them easier to scan.

Finally, I removed the hover effect from the cards, as that implied that you could interact with it, e.g. click it to get to the card page. Instead, you have to use the button at the bottom.

An, and this fixes #217.