### PR TITLE
[fix] Move sign-up link to the right

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,8 +11,6 @@
     <% unless current_user.nil? %>
     <%= link_to "Add a point", new_point_path, class: "btn btn-primary btn-sm" %>
     <%= link_to "Add a service", new_service_path, class: "btn btn-primary btn-sm" %>
-    <% else %>
-    <%= link_to "Sign up to contribute", new_user_registration_path, class: "btn btn-primary btn-sm" %>
     <% end %>
   </div>
   <!-- Right Navigation -->
@@ -54,6 +52,7 @@
         </ul>
         <% else %>
         <%= link_to t(".sign_in", default: "Login"), new_user_session_path, class: "navbar-tosdr-item navbar-tosdr-link dropdown-toggle", id: "navbar-tosdr-menu" %>
+        <%= link_to "Sign up to contribute", new_user_registration_path, class: "btn btn-primary btn-sm" %>
         <% end %>
       </div>
     </div>
@@ -74,6 +73,7 @@
         <% else %>
         <li><%= link_to "About", about_path, class: "navbar-tosdr-item navbar-tosdr-link" %></li>
         <li><%= link_to t(".sign_in", default: "Login"), new_user_session_path, class: "navbar-tosdr-item navbar-tosdr-link dropdown-toggle", id: "navbar-tosdr-menu" %></li>
+        <li><%= link_to "Sign up", new_user_registration_path, class: "navbar-tosdr-item navbar-tosdr-link dropdown-toggle" %></li>
         <% end %>
       </ul>
     </div>


### PR DESCRIPTION
Since sign-up and login are related, I've placed them next to
eachother: in the top right-hand side, where I think most sites
place them.

Since sign-up is also more important in the conversion path than
login, I've kept that to be the primary action. Log in is only
needed when the user logs out, and since it will be done more than
once, it can be learned.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Fixes #224.

Note that I did not make them look alike as mentioned in that issue, since it's always good to maintain a clear hierarchy in your designs, and the sign-up button is the most important element in the sign-up funnel. (Except on mobile, where there was not really room to visually separate the two.)
