### PR TITLE
Fix #430: "Pending points" view shows all points

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -2,10 +2,13 @@ class PointsController < ApplicationController
   before_action :authenticate_user!, except: [:show]
   before_action :set_curator, only: [:edit, :featured, :destroy]
   before_action :set_point, only: [:show, :edit, :featured, :update, :destroy]
-  before_action :points_get, only: [:index]
 
   def index
-    @points = Point.all
+    if params[:scope].nil? || params[:scope] == "all"
+      @points = Point.includes(:service).all
+    elsif params[:scope] == "pending"
+      @points = Point.all.where(status: "pending")
+    end
     if @query = params[:query]
       @points = Point.includes(:service).search_points_by_multiple(@query)
     end
@@ -142,14 +145,6 @@ class PointsController < ApplicationController
 
   def point_params
     params.require(:point).permit(:title, :source, :status, :rating, :analysis, :topic_id, :service_id, :is_featured, :query, :point_change, :case_id, :quoteDoc, :quoteRev, :quoteStart, :quoteEnd, :quoteText)
-  end
-
-  def points_get
-    if params[:scope].nil? || params[:scope] == "all"
-      @points = Point.includes(:service).all
-    elsif params[:scope] == "pending"
-      @points = Point.includes(:service).all.where(status: "pending")
-    end
   end
 
   def set_curator


### PR DESCRIPTION
The points view would _always_ load all points (in a greedy matter, too), even when you opted to just look at pending points.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Thanks !
