### PR TITLE
[fix] Save selections back to the database

### DIFF
--- a/app/views/points/_full_form.html.erb
+++ b/app/views/points/_full_form.html.erb
@@ -113,7 +113,7 @@
               + encodeURIComponent('<%= @service_url %>') + '/'
               + point_quoteDoc.value, true)
             xhr.onload = function() {
-              ta.innerHTML = xhr.response
+              ta.textContent = xhr.response
               ta.selectionStart = parseInt(<%= @point.quoteStart %>)
               ta.selectionEnd = parseInt(<%= @point.quoteEnd %>)
               var PX_PER_CHAR = .55 // this is an estimate
@@ -138,9 +138,17 @@
           }
           fetchDocList()
           setInterval(function() {
-            point_quoteStart.value = ta.selectionStart
-            point_quoteEnd.value = ta.selectionEnd
-            point_quoteText.value = ta.value.substring(ta.selectionStart, ta.selectionEnd)
+            var selection = document.getSelection();
+            if (
+              selection.anchorNode !== null
+              && selection.anchorNode.parentElement
+              && selection.anchorNode.parentElement.id
+              && selection.anchorNode.parentElement.id === 'ta'
+            ) {
+              point_quoteStart.value = Math.min(selection.anchorOffset, selection.focusOffset)
+              point_quoteEnd.value = Math.max(selection.anchorOffset, selection.focusOffset)
+              point_quoteText.value = selection.toString()
+            }
           }, 250)
         </script>
       </div>


### PR DESCRIPTION
The previous method of checking which text was selected
(.selectionStart and .selectionEnd) only worked on textareas,
which we removed. This now works again.

Also, the HTML of the scraped website was displayed - this commit
makes it so it's displayed as text.

The thing that doesn't work yet, and for which I think there's no
API available, it _setting_ the text selection to whatever was
previously selected.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Thanks !
