### PR TITLE
[enh] Allow marking a service's review as complete

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -93,7 +93,7 @@ class ServicesController < ApplicationController
   end
 
   def service_params
-    params.require(:service).permit(:name, :url, :query, :wikipedia)
+    params.require(:service).permit(:name, :url, :query, :wikipedia, :is_comprehensively_reviewed)
   end
 
   def set_curator

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -5,6 +5,7 @@
         <%= f.input :name, placeholder: "Service name" %>
         <%= f.input :url, placeholder: "Address of the service"%>
         <%= f.input :wikipedia, placeholder: "Wikipedia link", hint: "This will be used to referrenced the Wikipedia link of the service. Used mostly for the API." %>
+        <%= f.input :is_comprehensively_reviewed, label: "This service's ToS;DR review is <a href=\"https://github.com/tosdr/tosdr.org/wiki/checklist\" target=\"_blank\" title=\"Checklist for service reviews\">comprehensive</a> and ready for publication.".html_safe, checked_value: true, unchecked_value: false %>
       </div>
       <div class="form-actions col-xs-4 col-sm-2 col-md-2">
           <%= link_to "Back", :back, class: "btn btn-default" %>

--- a/db/migrate/20180619101908_add_is_comprehensively_reviewed_to_services.rb
+++ b/db/migrate/20180619101908_add_is_comprehensively_reviewed_to_services.rb
@@ -1,0 +1,5 @@
+class AddIsComprehensivelyReviewedToServices < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :is_comprehensively_reviewed, :boolean, :null => false, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 20180622124325) do
     t.string "keywords"
     t.string "related"
     t.string "slug"
+    t.boolean "is_comprehensively_reviewed", default: false, null: false
   end
 
   create_table "topics", force: :cascade do |t|


### PR DESCRIPTION
* [] Are you working on the latest release?
* [ ] Have you tested it locally?
* [ ] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [ ] Please explain your change
* [ ] If necessary, have you documented your feature on the wiki? 

This is necessary for new ratings to actually show up on tosdr.org. Once a service has been marked as complete, the export script can include the ratings for services as calculated by Phoenix (see #459).

Note that services that currently have a rating available on tosdr.org are not yet marked as complete by the migration script, which might either be relevant for the export script, or require us to manually mark them as complete in the Phoenix interface.

Fixes #458.