### PR TITLE
[enh] Use input[type="number"] for case weight

### DIFF
--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -4,7 +4,7 @@
       <div class="form-inputs col-xs-12">
         <%= f.input :title, placeholder: "Case title", label: 'Title' %>
         <%= f.input :classification, as: :radio_buttons, collection: [['blocker', 'blocker'], ['bad', 'bad'], ['neutral', 'neutral'], ['good', 'good']] %>
-        <%= f.input :score, collection: 0..100, selected: 50, label: 'Weight', hint: "Range: 0..100. Higher weight make good points extra good, and bad/blocker points extra bad. Higher weight points have more impact on a service's rating, and are also displayed more prominently in the review summaries on https://tosdr.org." %>
+        <%= f.input :score, placeholder: 50, input_html: { min: 0, max: 100, value: @case.score || 50 }, label: 'Weight', hint: "Range: 0..100. Higher weight make good points extra good, and bad/blocker points extra bad. Higher weight points have more impact on a service's rating, and are also displayed more prominently in the review summaries on https://tosdr.org." %>
         <%= f.association :topic, collection: Topic.order('title ASC'), hint: "Pick the topic where the case applies" %>
         <%= f.input :description, as: :text , input_html: { rows: 3, class: "text-area" } %>
         <%= f.input :privacy_related, label: "This case is related to privacy, meaning it will affect <a href=\"https://spreadprivacy.com/privacy-simplified/\">DuckDuckGo's Privacy Grade</a>.".html_safe, checked_value: true, unchecked_value: false %>


### PR DESCRIPTION
The case weight was transformed to a drop-down to be able to set a
min and a max value, but this is also possible with the more
appropriate input[type="number"].

Furthermore, the weight is now set to 50 by default for new cases.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Thanks !
