### PR TITLE
[mod] Link documents to points through a foreign key

### DIFF
--- a/db/migrate/20180802102507_add_document_ref_to_points.rb
+++ b/db/migrate/20180802102507_add_document_ref_to_points.rb
@@ -1,0 +1,28 @@
+class AddDocumentRefToPoints < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :points, :document, foreign_key: true
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE points AS p
+          SET document_id = d.id
+          FROM documents AS d
+          WHERE p.service_id = d.service_id AND p."quoteDoc" = d.name AND p."quoteText" IS NOT NULL
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          UPDATE points AS p
+          SET "quoteDoc" = d.name, "quoteRev" = 'latest'
+          FROM documents AS d
+          WHERE p.service_id = d.service_id AND p.document_id = d.id AND p."quoteText" IS NOT NULL
+        SQL
+      end
+    end
+
+    remove_column :points, :quoteDoc, :string
+    remove_column :points, :quoteRev, :string
+  end
+end


### PR DESCRIPTION
Fixes #569 - documents are now linked to points through a foreign key, rather than through a string. This improves performance and prevents data corruption.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Thanks !
