### PR TITLE
[enh] Only link to the annotation view with documents

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,6 +4,7 @@ class ServicesController < ApplicationController
 
   def index
     @services = Service.includes(points: [:case]).all
+    @document_counts = Document.group(:service_id).count
     if @query = params[:query]
       @services = Service.search_by_name(@query)
     end

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -60,9 +60,11 @@
               </div>
             </div>
             <div class="card-inline-item card-inline-options">
+              <% if @document_counts[s.id] && @document_counts[s.id] > 0 %>
               <%= link_to(annotate_service_path(s), class: 'btn') do %>
                 <i class="fa fa-bookmark" aria-hidden="true"></i>
                 <% end %>
+              <% end %>
               <%= link_to(service_path(s), class: 'btn') do %>
                 <i class="fa fa-eye" aria-hidden="true"></i>
                 <% end %>


### PR DESCRIPTION
In the service list, only show a link to the annotation view when
documents have already been defined for that service.
This has two advantages:

- Since adding documents currently requires knowledge of XPaths,
  this makes it easy for contributors to see which services they
   can immediately start annotating.
- For people who do understand XPath, it's easier to see which
  services should still have XPaths added to them.

Longer-term, when annotation is the default mode, we can probably
show them all the time again. In fact, it'd probably be the
default target when you click the service name.

Fixes #623.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Thanks !
