### PR TITLE
[fix] Sanitise content _after_ hiding included tags

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,10 +29,10 @@ module ApplicationHelper
   end
 
   def hide_tags(snippet)
-    snippet
-    # sanitize(snippet)
-    #   .gsub(/<(.*?)>/, '<span class="hiddenTag">&lt;\1&gt;</span>')
-    #   .html_safe
+    sanitize(
+      snippet
+      .gsub(/<(.*?)>/, '<span class="hiddenTag">&lt;\1&gt;</span>')
+    ).html_safe
   end
 
   def format_time(time)


### PR DESCRIPTION
Sanitize apparently removes tags it doesn't recognise (such as
<u>) and closes unclosed tags. This is undesirable for tags
crawled from a site's terms of service, since we want to preserve
its structure. It's also unnecessary, since those tags are not
parsed anyway, but displayed verbatim on-screen (in lieu of
successfully hiding them). Hence, we now first make sure that
they're displayed (by replacing `<` with `&lt;`, and likewise for
`>`), and only then sanitise our HTML.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please mention if it is a fix (fix), enhancement (enh), modification (mod) or security (sec)
* [x] Please explain your change
* [x] If necessary, have you documented your feature on the wiki? 

Thanks !

Fixes #645, properly.