### PR TITLE
Only suggest point authors to link points to docs

### DIFF
--- a/app/views/points/show.html.erb
+++ b/app/views/points/show.html.erb
@@ -72,11 +72,11 @@
 <%- # We only link to the annotate view if documents are already available, -%>
 <%- # since it currently is a challenge to add new documents (you need to know XPath). -%>
 <%- # We can switch to always showing the link when annotation is the default way of reviewing. -%>
-<% elsif current_user && @point.service.documents.count > 0 %>
+<% elsif current_user && current_user.id == @point.user_id && @point.service.documents.count > 0 %>
   <div class="row" style="margin-bottom: 1rem">
     <div class="col-sm-10 col-sm-offset-1 p30 bgw">
       <p>
-        This point is not yet linked to a passage in this service's documents.
+        This point is not linked to a passage in this service's documents.
         <%= link_to  "Link it now?", annotate_point_path(@point.service_id, @point.id) %>
       </p>
     </div>


### PR DESCRIPTION
Fixes #685. Only point authors are now prompted to link that point
to a quote. (Since c601c6c9e785cc782f636d911df4dec5ee69473b, only
authors are allowed to do so.)

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please explain your change

Thanks !
