### PR TITLE
Literally display HTML entities in a document

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,6 +52,7 @@ module ApplicationHelper
     sanitize(
       snippet
       .gsub(/<(.*?)>/, '<span class="hiddenTag">&lt;\1&gt;</span>')
+      .gsub(/&(.*?);/, '&amp;\1;')
     ).html_safe
   end
 


### PR DESCRIPTION
Although it's a shame that they are shown as such to the user, I
don't think there's a way of showing the referenced character while
having the HTML entity code be included in the selection (like
HTML tags are hidden but still included in the selection). Thus,
simply display the original HTML entity code.

Fixes #684.

* [ ] Are you working on the latest release?
* [ ] Have you tested it locally?
* [ ] Please explain your change

Thanks !
