### PR TITLE
Revert "Add a clarifying comment about showing entities"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,9 +52,6 @@ module ApplicationHelper
     sanitize(
       snippet
       .gsub(/<(.*?)>/, '<span class="hiddenTag">&lt;\1&gt;</span>')
-      # HTML entities should not be rendered to the referenced character, because then those
-      # characters will be included in an annotator's selection, instead of the entity, and thus it
-      # won't be found in the original document:
       .gsub(/&(.*?);/, '&amp;\1;')
     ).html_safe
   end


### PR DESCRIPTION
Reverts tosdr/phoenix#690

Wow. For some reason this broke everything; apparently the comment breaks up the function chain or something. Sorry about that.

I'd move the comment, but that detaches it from the string it is about, so I guess future readers will have to do with the commit message...