### PR TITLE
Fix selecting text containing hidden tags

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,8 +51,8 @@ module ApplicationHelper
   def hide_tags(snippet)
     sanitize(
       snippet
-      .gsub(/<(.*?)>/, '<span class="hiddenTag">&lt;\1&gt;</span>')
       .gsub(/&(.*?);/, '&amp;\1;')
+      .gsub(/<(.*?)>/, '<span class="hiddenTag">&lt;\1&gt;</span>')
     ).html_safe
   end
 


### PR DESCRIPTION
I replaced special characters with their literal HTML entities, but
I did that after inserting my own special characters inside the
hidden tag. Switching over the order of the substitutions fixes it.

Fixes #684.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please explain your change

Thanks !
