### PR TITLE
List recently updated points first for curators

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,6 +8,7 @@ class PagesController < ApplicationController
                   .includes(:service)
                   .includes(:case)
                   .includes(:user)
+                  .order(updated_at: :desc)
                   .limit(10)
     end
 


### PR DESCRIPTION
As opposed to points that were imported long ago, people who've
recently contributed to Phoenix probably care most, their points
are more likely to still be accurate, and their continued
participation would most benefit from their points quickly showing
up. Therefore make sure that pending points that have recently been
updated are listed first for curators.

Fixes #713.

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please explain your change

