### PR TITLE
adds mechanism for restoring missing quotes in document annotate view

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -8,7 +8,7 @@ class DocumentsController < ApplicationController
   include Pundit
 
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_document, only: [:show, :edit, :update, :crawl]
+  before_action :set_document, only: [:show, :edit, :update, :crawl, :restore_points]
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
@@ -63,18 +63,17 @@ class DocumentsController < ApplicationController
     if @document.save
       # only want to do this if XPath or URL have changed - the theory is that text is returned blank when there's a defunct URL or XPath to avoid server error upon 404 error in the crawler
       # need to alert people if the crawler wasn't able to retrieve any text...
-	  
       if crawlresult != nil
-		if crawlresult["error"]
-			flash[:alert] = "It seems that our crawler wasn't able to retrieve any text. Please check that the XPath and URL are accurate.<br><br>Reason: "+ crawlresult["message"]["name"].to_s + "<br>Stacktrace: "+ CGI.escapeHTML(crawlresult["message"]["remoteStacktrace"].to_s)
-			redirect_to document_path(@document)
-		else
-			flash[:notice] = "The crawler has updated the document"
-			redirect_to document_path(@document)
-		end
-	  else
-		redirect_to document_path(@document)
-	  end
+    		if crawlresult["error"]
+    			flash[:alert] = "It seems that our crawler wasn't able to retrieve any text. <br><br>Reason: "+ crawlresult["message"]["name"].to_s + "<br>Stacktrace: "+ CGI.escapeHTML(crawlresult["message"]["remoteStacktrace"].to_s)
+    			redirect_to document_path(@document)
+    		else
+    			flash[:notice] = "The crawler has updated the document"
+    			redirect_to document_path(@document)
+    		end
+  	  else
+  		   redirect_to document_path(@document)
+  	  end
     else
       render 'edit'
     end
@@ -100,14 +99,32 @@ class DocumentsController < ApplicationController
 
   def crawl
     authorize @document
-	crawlresult = perform_crawl
+	  crawlresult = perform_crawl
     if crawlresult["error"]
-	  flash[:alert] = "It seems that our crawler wasn't able to retrieve any text. Please check that the XPath and URL are accurate.<br><br>Reason: "+ crawlresult["message"]["name"].to_s + "<br>Stacktrace: "+ CGI.escapeHTML(crawlresult["message"]["remoteStacktrace"].to_s)
-	  redirect_to document_path(@document)
-	else
-	flash[:notice] = "The crawler has updated the document"
-	redirect_to document_path(@document)
-	end
+      flash[:alert] = "It seems that our crawler wasn't able to retrieve any text. <br><br>Reason: "+ crawlresult["message"]["name"].to_s + "<br>Stacktrace: "+ CGI.escapeHTML(crawlresult["message"]["remoteStacktrace"].to_s)
+	    redirect_to document_path(@document)
+	  else
+	    flash[:notice] = "The crawler has updated the document"
+	    redirect_to document_path(@document)
+	  end
+  end
+
+  def restore_points
+    authorize @document
+
+    points_to_restore = @document.snippets[:points_needing_restoration]
+    restored = []
+    not_restored = []
+
+    points_to_restore.each do |point|
+      point.restore ? restored << point.id : not_restored << point.id
+    end
+
+    message = "Restored #{restored.length} points."
+    message = message + " Unable to restore #{not_restored.length} points." if not_restored.any?
+    flash[:alert] = message
+    
+    redirect_to annotate_path(@document.service)
   end
 
   private
@@ -118,7 +135,7 @@ class DocumentsController < ApplicationController
   end
 
   def set_document
-    @document = Document.find(params[:id])
+    @document = Document.find(params[:id].to_i)
   end
 
   def document_params
@@ -135,51 +152,53 @@ class DocumentsController < ApplicationController
     })
 
     @tbdoc.scrape
-	
-	if @tbdoc.apiresponse["error"]
-		return @tbdoc.apiresponse
-	end
-	
-	if not @document.text.blank?
-		oldLength = @document.text.length
-		oldCRC = Zlib::crc32(@document.text)
-	else
-		oldLength = 0
-		oldCRC = 0
-	end
-	newCRC =  Zlib::crc32(@tbdoc.newdata)
-	
-	if oldCRC == newCRC
-		@tbdoc.apiresponse["error"] = true
-		@tbdoc.apiresponse["message"]["name"] = "The source document has not been updated. No changes made."
-		@tbdoc.apiresponse["message"]["remoteStacktrace"] = "SourceDocument"
-		return @tbdoc.apiresponse
-	else
-		@document.update(text: @tbdoc.newdata)
-		newLength = @document.text.length
-		
 
-		# There is a cron job in the crontab of the 'tosdr' user on the forum.tosdr.org
-		# server which runs once a day and before it deploys the site from edit.tosdr.org
-		# to tosdr.org, it will run the check_quotes script from
-		# https://github.com/tosdr/tosback-crawler/blob/225a74b/src/eto-admin.js#L121-L123
-		# So that if text has moved without changing, points are updated to the corrected
-		# quoteStart, quoteEnd, and quoteText values where possible, and/or their status is
-		# switched between:
-		# pending <-> pending-not-found
-		# approved <-> approved-not-found
-		@document_comment = DocumentComment.new()
-		@document_comment.summary = '<span class="label label-info">Document has been crawled</span><br><b>Old length:</b> <kbd>' + oldLength.to_s + ' CRC ' + oldCRC.to_s + '</kbd><br><b>New length:</b> <kbd>' + newLength.to_s + ' CRC ' + newCRC.to_s + '</kbd>'
-		@document_comment.user_id = current_user.id
-		@document_comment.document_id = @document.id
+  	if @tbdoc.apiresponse["error"]
+  		return @tbdoc.apiresponse
+  	end
 
-		if @document_comment.save
-		  puts "Comment added!"
-		else
-		  puts "Error adding comment!"
-		  puts @document_comment.errors.full_messages
-		end
-		return @tbdoc.apiresponse
+  	if not @document.text.blank?
+  		oldLength = @document.text.length
+  		oldCRC = Zlib::crc32(@document.text)
+  	else
+  		oldLength = 0
+  		oldCRC = 0
+  	end
+
+    newCRC =  Zlib::crc32(@tbdoc.newdata)
+
+  	if oldCRC == newCRC
+  		@tbdoc.apiresponse["error"] = true
+  		@tbdoc.apiresponse["message"]["name"] = "The source document has not been updated. No changes made."
+  		@tbdoc.apiresponse["message"]["remoteStacktrace"] = "SourceDocument"
+  		return @tbdoc.apiresponse
+  	else
+  		@document.update(text: @tbdoc.newdata)
+  		newLength = @document.text.length
+
+
+  		# There is a cron job in the crontab of the 'tosdr' user on the forum.tosdr.org
+  		# server which runs once a day and before it deploys the site from edit.tosdr.org
+  		# to tosdr.org, it will run the check_quotes script from
+  		# https://github.com/tosdr/tosback-crawler/blob/225a74b/src/eto-admin.js#L121-L123
+  		# So that if text has moved without changing, points are updated to the corrected
+  		# quoteStart, quoteEnd, and quoteText values where possible, and/or their status is
+  		# switched between:
+  		# pending <-> pending-not-found
+  		# approved <-> approved-not-found
+  		@document_comment = DocumentComment.new()
+  		@document_comment.summary = '<span class="label label-info">Document has been crawled</span><br><b>Old length:</b> <kbd>' + oldLength.to_s + ' CRC ' + oldCRC.to_s + '</kbd><br><b>New length:</b> <kbd>' + newLength.to_s + ' CRC ' + newCRC.to_s + '</kbd>'
+  		@document_comment.user_id = current_user.id
+  		@document_comment.document_id = @document.id
+
+  		if @document_comment.save
+  		  puts "Comment added!"
+  		else
+  		  puts "Error adding comment!"
+  		  puts @document_comment.errors.full_messages
+  		end
+
+      return @tbdoc.apiresponse
     end
   end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -29,7 +29,7 @@ class ServicesController < ApplicationController
 
   def new
     authorize Service
-	
+
 	if current_user && (current_user.admin? || current_user.curator? || current_user.bot?)
 		@service = Service.new
 	else
@@ -71,7 +71,7 @@ class ServicesController < ApplicationController
   def annotate
     authorize Service
 
-    @service = Service.includes(documents: [:points]).find(params[:id] || params[:service_id])
+    @service = Service.includes(documents: [:points, :user]).find(params[:id] || params[:service_id])
     @documents = @service.documents
     if (params[:point_id] && current_user)
       @point = Point.find_by id: params[:point_id]

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -20,4 +20,14 @@ class Point < ApplicationRecord
   def self.search_points_by_multiple(query)
     Point.joins(:service).where('services.name ILIKE ? or points.status ILIKE ? OR points.title ILIKE ?', "%#{query}%", "%#{query}%", "%#{query}%")
   end
+
+  def restore
+    quote_start = self.document.text.index(self.quoteText)
+    quote_end = quote_start + self.quoteText.length
+
+    self.quoteStart = quote_start
+    self.quoteEnd = quote_end
+
+    self.save
+  end
 end

--- a/app/policies/document_policy.rb
+++ b/app/policies/document_policy.rb
@@ -23,6 +23,10 @@ class DocumentPolicy < ApplicationPolicy
     (!user.nil? && user.curator?) || (!user.nil? && user.admin?)
   end
 
+  def restore_points?
+    is_owner?
+  end
+
   private
 
   def is_owner?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,47 +1,47 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-  <!-- Facebook Open Graph data -->
-  <meta property="og:title" content="<%= meta_title %>" />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="<%= request.original_url %>" />
-  <meta property="og:image" content="<%= meta_image %>" />
-  <meta property="og:description" content="<%= meta_description %>" />
-  <meta property="og:site_name" content="<%= meta_title %>" />
+    <!-- Facebook Open Graph data -->
+    <meta property="og:title" content="<%= meta_title %>" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="<%= request.original_url %>" />
+    <meta property="og:image" content="<%= meta_image %>" />
+    <meta property="og:description" content="<%= meta_description %>" />
+    <meta property="og:site_name" content="<%= meta_title %>" />
 
-  <!-- Twitter Card data -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="<%= DEFAULT_META["twitter_account"] %>">
-  <meta name="twitter:title" content="<%= meta_title %>">
-  <meta name="twitter:description" content="<%= meta_description %>">
-  <meta name="twitter:creator" content="<%= DEFAULT_META["twitter_account"] %>">
-  <meta name="twitter:image:src" content="<%= meta_image %>">
+    <!-- Twitter Card data -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="<%= DEFAULT_META["twitter_account"] %>">
+    <meta name="twitter:title" content="<%= meta_title %>">
+    <meta name="twitter:description" content="<%= meta_description %>">
+    <meta name="twitter:creator" content="<%= DEFAULT_META["twitter_account"] %>">
+    <meta name="twitter:image:src" content="<%= meta_image %>">
 
-  <%= favicon_link_tag %>
+    <%= favicon_link_tag %>
 
-<% if content_for?(:title) %>
-  <%= content_for(:title) %>
-<% else %>
-  <title>Terms Of Service; Didn't Read</title>
-<% end %>
+    <% if content_for?(:title) %>
+      <%= content_for(:title) %>
+    <% else %>
+      <title>Terms Of Service; Didn't Read</title>
+    <% end %>
 
-  <%= csrf_meta_tags %>
-  <%= action_cable_meta_tag %>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
-</head>
-<body class="<%= controller_name %> <%= action_name %>">
-  <%= render "shared/navbar" %>
-  <%= render "shared/flashes" %>
-  <div class="container">
-    <%= yield %>
-  </div>
-  <%= render "shared/footer" %>
-  <%= javascript_include_tag 'application' %>
-  <script src="https://rksyl9kf1wtg.statuspage.io/embed/script.js"></script>
-  <script type="text/javascript" src="https://tosdr.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/sb53l8/b/24/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=a3477685"></script>
-</body>
+    <%= csrf_meta_tags %>
+    <%= action_cable_meta_tag %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+  </head>
+  <body class="<%= controller_name %> <%= action_name %>">
+    <%= render "shared/navbar" %>
+    <%= render "shared/flashes" %>
+    <div class="container">
+      <%= yield %>
+    </div>
+    <%= render "shared/footer" %>
+    <%= javascript_include_tag 'application' %>
+    <script src="https://rksyl9kf1wtg.statuspage.io/embed/script.js"></script>
+    <script type="text/javascript" src="https://tosdr.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/sb53l8/b/24/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=a3477685"></script>
+  </body>
 </html>

--- a/app/views/services/annotate.html.erb
+++ b/app/views/services/annotate.html.erb
@@ -11,38 +11,39 @@
   <input type="hidden" name="quoteCaseId" id="quoteCaseId">
 </form>
 
+
 <h2><%= link_to  @service.name, service_path(@service) %></h2>
 
 <% if @topics %>
-<div class="lead">
-  Highlight lines that are of interest to users to link them to a case.
-</div>
-<div id="caseToast" class="toast">
-  <form id="caseDropdown">
-    <select>
-      <% @topics.each do |topic| %>
-        <optgroup label="<%= topic.title %>">
-          <% topic.cases.each do |c| %>
-            <option data-case-id="<%= c.id %>"><%= c.title %></option>
-          <% end %>
-        </optgroup>
-      <% end %>
-    </select>
-    <button type="submit" class="btn btn-primary">Annotate</button>
-  </form>
-</div>
-<% else %>
-<div class="lead">
-  Highlight the lines that support the point <i><%= @point.title %></i>.
-</div>
-<div id="pointToast" class="toast">
-  <form id="pointForm">
-    <div class="form-group">
-      <%= @point.title %>
-    </div>
-    <button type="submit" class="btn btn-primary">Link to this excerpt</button>
-  </form>
-</div>
+  <div class="lead">
+    Highlight lines that are of interest to users to link them to a case.
+  </div>
+  <div id="caseToast" class="toast">
+    <form id="caseDropdown">
+      <select>
+        <% @topics.each do |topic| %>
+          <optgroup label="<%= topic.title %>">
+            <% topic.cases.each do |c| %>
+              <option data-case-id="<%= c.id %>"><%= c.title %></option>
+            <% end %>
+          </optgroup>
+        <% end %>
+      </select>
+      <button type="submit" class="btn btn-primary">Annotate</button>
+    </form>
+  </div>
+  <% else %>
+  <div class="lead">
+    Highlight the lines that support the point <i><%= @point.title %></i>.
+  </div>
+  <div id="pointToast" class="toast">
+    <form id="pointForm">
+      <div class="form-group">
+        <%= @point.title %>
+      </div>
+      <button type="submit" class="btn btn-primary">Link to this excerpt</button>
+    </form>
+  </div>
 <% end %>
 
 <div id="toc">
@@ -53,11 +54,11 @@
         <a href="#doc_<%= doc.id %>"><%= doc.name %></a>
       </li>
     <% end %>
-	<% if policy(@service).create? %>
-        <li style="list-style-type: none; padding-top: 1rem;">
-            <%= link_to "Add a document", new_document_path(service: @service), title: "Add a new document to crawl", class: "btn btn-default" %>
-		</li>
-	<% end %>
+  	<% if policy(@service).create? %>
+      <li style="list-style-type: none; padding-top: 1rem;">
+        <%= link_to "Add a document", new_document_path(service: @service), title: "Add a new document to crawl", class: "btn btn-primary" %>
+  		</li>
+  	<% end %>
   </ul>
 </div>
 
@@ -65,13 +66,20 @@
   <% @documents.each do |doc| %>
     <div class="docAnchor" id="doc_<%= doc.id %>">
       <div class="panel panel-default">
-        <div
-          class="panel-heading"
-        ><h3 class="h5"><%= link_to doc.name, document_path(doc) %></h3>
+        <div class="panel-heading pb-2">
+          <h3><%= link_to doc.name, document_path(doc) %></h3>
+          <% if policy(doc).restore_points? %>
+            <% if doc.snippets[:points_needing_restoration].present? %>
+              <%= link_to("Restore quotes", document_restore_points_path(doc), method: :post, class: 'btn btn-sm btn-warning') %>
+              <div>
+                <small>Quotes for certain points were not found. Click here to try to restore them.</small>
+              </div>
+            <% end %>
+          <% end %>
         </div>
         <div class="panel-body documentContent" data-content="<%= doc.text %>">
           <% offset = 0 %>
-          <% doc.snippets.each do |snippet| %>
+          <% doc.snippets[:snippets].each do |snippet| %>
             <% if snippet[:pointId] %>
               <p><%= link_to hide_tags(snippet[:text]), point_path(snippet[:pointId]), title: snippet[:title], :data => { :document_id => doc.id, :offset => offset }%></p>
             <% else %>
@@ -84,4 +92,5 @@
     </div>
   <% end %>
 </div>
+
 <%= link_to("Add a point not linked to a document", new_service_point_path(@service), class: 'btn btn-primary') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   post "documents/new", to: "documents#create"
   post "documents/:id/edit", to: "documents#update"
   post "documents/:id/crawl", to: "documents#crawl", as: :document_crawl
+  post "documents/:id/restore_points", to: 'documents#restore_points', as: :document_restore_points
 
   # api endpoints for vue
   get "services/list_all", to: "services#list_all", as: "list_all_services"


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [->] Please explain your change

there's an edge case in production where, due to formatting changes picked up by the crawler, the annotate page for certain services is no longer displaying the quotes, even if they still exist in the document. this adds an option to try to 'restore' the quotes by updating the quoteStart and quoteEnd of the point in question based on its new position in the document.

Thanks !
